### PR TITLE
Add support for vertical gestures

### DIFF
--- a/version2/GestureBuilder/src/pack/GestureApp/GestureActivity.java
+++ b/version2/GestureBuilder/src/pack/GestureApp/GestureActivity.java
@@ -24,6 +24,7 @@ public class GestureActivity extends Activity {
 
         GestureOverlayView gestures = (GestureOverlayView) findViewById(R.id.gestures);
         gestures.addOnGesturePerformedListener(handleGestureListener);
+        gestures.setGestureStrokeAngleThreshold(90.0f);
     }
 
     /**

--- a/version2/GestureBuilder/src/pack/GestureApp/GestureListActivity.java
+++ b/version2/GestureBuilder/src/pack/GestureApp/GestureListActivity.java
@@ -12,8 +12,8 @@ import android.util.Log;
 import android.view.MenuItem;
 import android.view.View;
 import android.widget.*;
-import com.example.GestureApp.GestureAdapter;
-import com.example.GestureApp.GestureHolder;
+import pack.GestureApp.GestureAdapter;
+import pack.GestureApp.GestureHolder;
 import pack.GestureApp.R;
 
 import java.util.ArrayList;


### PR DESCRIPTION
Vertical gestures, i.e. straight lines up or down, are not detected while testing. I've implemented this in my fork, by using the solution from http://stackoverflow.com/a/22807326.
